### PR TITLE
Run distance function benchmarks as a group

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ Benchmark
 ```
 $ cargo bench
 
-flat                    time:   [329.01 ps 331.10 ps 333.29 ps]
-haversine               time:   [12.244 ns 12.338 ns 12.437 ns]
-vincenty                time:   [262.92 ns 266.14 ns 270.01 ns]
+distance/flat           time:   [22.727 ns 22.955 ns 23.196 ns]
+distance/haversine      time:   [63.349 ns 64.046 ns 64.787 ns]
+distance/vincenty       time:   [358.10 ns 363.16 ns 369.46 ns]
 ```
 
-According to these results the flat surface approximation is about 37x faster
+According to these results the flat surface approximation is about 3x faster
 than the [Haversine] formula.
 
 [Haversine]: https://en.wikipedia.org/wiki/Haversine_formula

--- a/benches/distance_benchmark.rs
+++ b/benches/distance_benchmark.rs
@@ -3,7 +3,7 @@ extern crate criterion;
 extern crate flat_projection;
 
 use std::f64;
-use criterion::Criterion;
+use criterion::{Criterion, Fun};
 use flat_projection::FlatProjection;
 
 const AACHEN: (f64, f64) = (6.186389, 50.823194);
@@ -91,9 +91,13 @@ fn vincenty_distance(p1: (f64, f64), p2: (f64, f64)) -> f64 {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("flat", |b| b.iter(|| flat_distance(AACHEN, MEIERSBERG)));
-    c.bench_function("haversine", |b| b.iter(|| haversine_distance(AACHEN, MEIERSBERG)));
-    c.bench_function("vincenty", |b| b.iter(|| vincenty_distance(AACHEN, MEIERSBERG)));
+    let flat = Fun::new("flat", |b, &(from, to)| b.iter(|| flat_distance(from, to)));
+    let haversine = Fun::new("haversine", |b, &(from, to)| b.iter(|| haversine_distance(from, to)));
+    let vincenty = Fun::new("vincenty", |b, &(from, to)| b.iter(|| vincenty_distance(from, to)));
+
+    let distance = vec!(flat, haversine, vincenty);
+
+    c.bench_functions("distance", distance, (AACHEN, MEIERSBERG));
 }
 
 criterion_group!(benches, criterion_benchmark);


### PR DESCRIPTION
see https://japaric.github.io/criterion.rs/book/user_guide/comparing_functions.html

unfortunately running with non-constant inputs also seems to change the benchmark results quite significantly which is reflected by the README change