### PR TITLE
FlatProjection: Return `FlatPoint` instances relative to the reference point

### DIFF
--- a/benches/distance_benchmark.rs
+++ b/benches/distance_benchmark.rs
@@ -10,7 +10,7 @@ const AACHEN: (f64, f64) = (6.186389, 50.823194);
 const MEIERSBERG: (f64, f64) = (6.953333, 51.301389);
 
 fn flat_distance(p1: (f64, f64), p2: (f64, f64)) -> f64 {
-    let proj = FlatProjection::new((p1.1 + p2.1) / 2.);
+    let proj = FlatProjection::new((p1.0 + p2.0) / 2., (p1.1 + p2.1) / 2.);
 
     let flat1 = proj.project(p1.0, p1.1);
     let flat2 = proj.project(p2.0, p2.1);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -10,9 +10,10 @@ fn it_works() {
     let aachen = (6.186389, 50.823194);
     let meiersberg = (6.953333, 51.301389);
 
+    let average_longitude = (aachen.0 + meiersberg.0) / 2.;
     let average_latitude = (aachen.1 + meiersberg.1) / 2.;
 
-    let proj = FlatProjection::new(average_latitude);
+    let proj = FlatProjection::new(average_longitude, average_latitude);
 
     let flat_aachen = proj.project(aachen.0, aachen.1);
     let flat_meiersberg = proj.project(meiersberg.0, meiersberg.1);


### PR DESCRIPTION
This is a rebased, cleaned up and slightly modified version of #12

The main advantage is that now the `FlatPoint` instances are relative to the reference point of the `FlatProjection`

This is a breaking change since the constructor API of `FlatProjection` changed.

Closes #12