### PR TITLE
Bump "Minimum Supported Rust Version" to v1.65.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.46.0
+          toolchain: 1.65.0
           override: true
           components: rustfmt, clippy
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@
 //! [cheap-ruler]: https://github.com/mapbox/cheap-ruler
 //! [cheap-ruler-cpp]: https://github.com/mapbox/cheap-ruler-cpp
 
+#![allow(clippy::derive_partial_eq_without_eq)]
+
 extern crate num_traits;
 
 use num_traits::Float;


### PR DESCRIPTION
This is unfortunately necessary because some transitive dependencies bumped their MSRVs without breaking change releases... 😫